### PR TITLE
Implement ENS Chain Resolver with ENSIP-10 support and reverse resolution

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,11 @@
+{
+  "lib/openzeppelin-contracts": {
+    "tag": {
+      "name": "v5.4.0",
+      "rev": "c64a1edb67b6e3f4a15cca8909c9482ad33a02b0"
+    }
+  },
+  "lib/openzeppelin-contracts-upgradeable": {
+    "rev": "e725abddf1e01cf05ace496e950fc8e243cc7cab"
+  }
+}

--- a/src/ChainResolver.sol
+++ b/src/ChainResolver.sol
@@ -3,62 +3,233 @@ pragma solidity ^0.8.25;
 
 /// @title ChainResolver
 /// @author @unruggable-labs
-/// @notice Minimal resolver that stores a single canonical chain-id record per node.
+/// @notice Extended resolver that stores chain-id records per label using ENSIP-10 interface.
+/// @dev This resolver works by:
+///      - Taking DNS-encoded names and extracting the first label hash
+///      - Storing and resolving address, contenthash, text, and data records per label hash
+///      - For "chain-id" text records, returns hex-encoded chain ID from chainIDRegistry
+///      - For "chain-id" data records, returns raw chain ID bytes from chainIDRegistry
+///      - Supports multi-coin addresses with coinType parameter (default: 60 for Ethereum)
+///      - Includes ownership and operator management for label hashes
+///      - Uses AccessControl with ADMIN_ROLE for management functions
 
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
+import {HexUtils} from "@openzeppelin/contracts/utils/HexUtils.sol";
+import {IExtendedResolver} from "./interfaces/IExtendedResolver.sol";
+import {NameCoder} from "./utils/NameCoder.sol";
 
-interface IENSIPTBD9 {
-    event AddressChanged(bytes32 indexed node, uint256 key, bytes data);
-
-    function addr(bytes32 node, uint256 key) external view returns (bytes memory);
+interface IChainIDRegistry {
+    function chainName(bytes calldata _chainIdBytes) external view returns (string memory _chainName);
+    function chainId(bytes32 labelhash) external view returns (bytes memory _chainId);
 }
 
-contract ChainResolver is Ownable, IERC165, IENSIPTBD9 {
-    error InvalidKey();
+contract ChainResolver is AccessControl, IERC165, IExtendedResolver {
 
-    // keyGen("chain-id") = (uint256(keccak256("chain-id")) - 1) << 32
-    uint256 public constant CHAIN_ID_KEY = 0xa8c8594bfda2da5d8830d2367f8d6c34e565e2cf5616ba1ede2c620d00000000;
+    // Role constants
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
 
-    mapping(bytes32 => bytes) private chainIdRecords;
-    mapping(bytes32 => bytes32) private reverseMapping;
+    // ENS method selectors
+    bytes4 public constant ADDR_SELECTOR = bytes4(keccak256("addr(bytes32)"));
+    bytes4 public constant ADDR_COINTYPE_SELECTOR = bytes4(keccak256("addr(bytes32,uint256)"));
+    bytes4 public constant CONTENTHASH_SELECTOR = bytes4(keccak256("contenthash(bytes32)"));
+    bytes4 public constant TEXT_SELECTOR = bytes4(keccak256("text(bytes32,string)"));
+    bytes4 public constant DATA_SELECTOR = bytes4(keccak256("data(bytes32,bytes)"));
 
-    constructor() Ownable(msg.sender) {}
+    // Coin type constants
+    uint256 public constant ETHEREUM_COIN_TYPE = 60;
 
-    /// @notice Resolve the canonical chain-id bytes stored for a node.
-    /// @param _node The ENS node being queried.
-    /// @param _key The key being resolved.
-    function addr(bytes32 _node, uint256 _key) external view override returns (bytes memory) {
-        if (_key != CHAIN_ID_KEY) return bytes("");
-        return chainIdRecords[_node];
+    // Text record key constants
+    string public constant CHAIN_ID_TEXT_KEY = "chain-id";
+    
+    // Data record key constants
+    bytes public constant CHAIN_ID_DATA_KEY = "chain-id";
+
+    // Base node for cid.eth
+    bytes32 public constant BASE_NODE = keccak256(abi.encodePacked(bytes32(0), keccak256("cid")));
+
+
+    // ChainID Registry contract address
+    IChainIDRegistry public chainIDRegistry;
+
+    // Named mappings for better readability
+    mapping(bytes32 labelHash => mapping(uint256 coinType => address addr)) private addressRecords;
+    mapping(bytes32 labelHash => bytes contentHash) private contenthashRecords;
+    mapping(bytes32 labelHash => mapping(string key => string value)) private textRecords;
+    mapping(bytes32 labelHash => mapping(bytes key => bytes data)) private dataRecords;
+    
+    // Owner and operator mappings
+    mapping(bytes32 labelHash => address owner) private labelOwners;
+    mapping(address owner => mapping(address operator => bool authorized)) private operators;
+
+    constructor(address _chainIDRegistry) {
+        chainIDRegistry = IChainIDRegistry(_chainIDRegistry);
+        
+        // Set up roles
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(ADMIN_ROLE, msg.sender);
     }
 
-    /// @notice Store chain-id bytes for a node.
-    /// @param _node The ENS node to update.
-    /// @param _key The key that must equal CHAIN_ID_KEY.
-    /// @param _data Arbitrary bytes.
-    function setAddr(bytes32 _node, uint256 _key, bytes calldata _data) external onlyOwner {
-        if (_key != CHAIN_ID_KEY) revert InvalidKey();
-        bytes memory current = chainIdRecords[_node];
-        if (current.length != 0) {
-            delete reverseMapping[keccak256(current)];
+    /// @notice Resolve data for a DNS-encoded name using ENSIP-10 interface.
+    /// @param name The DNS-encoded name.
+    /// @param data The ABI-encoded ENS method call data.
+    /// @return The resolved data based on the method selector.
+    function resolve(bytes calldata name, bytes calldata data) external view override returns (bytes memory) {
+        // Extract the first label from the DNS-encoded name
+        (bytes32 labelHash, , , ) = NameCoder.readLabel(name, 0, true);
+        
+        // Get the method selector (first 4 bytes)
+        bytes4 selector = bytes4(data);
+        
+        if (selector == ADDR_SELECTOR) {
+            // addr(bytes32) - return address for Ethereum (coinType 60)
+            address addr = addressRecords[labelHash][ETHEREUM_COIN_TYPE];
+            return abi.encode(addr);
+        } else if (selector == ADDR_COINTYPE_SELECTOR) {
+            // addr(bytes32,uint256) - decode coinType and return address
+            (, uint256 coinType) = abi.decode(data[4:], (bytes32, uint256));
+            address addr = addressRecords[labelHash][coinType];
+            return abi.encode(addr);
+        } else if (selector == CONTENTHASH_SELECTOR) {
+            // contenthash(bytes32) - return content hash
+            bytes memory contentHash = contenthashRecords[labelHash];
+            return abi.encode(contentHash);
+        } else if (selector == TEXT_SELECTOR) {
+            // text(bytes32,string) - decode key and return text value
+            (, string memory key) = abi.decode(data[4:], (bytes32, string));
+            
+            // Special case for "chain-id" text record
+            if (keccak256(abi.encodePacked(key)) == keccak256(abi.encodePacked(CHAIN_ID_TEXT_KEY))) {
+                // Get chain ID bytes from registry and encode as hex string
+                bytes memory chainIdBytes = chainIDRegistry.chainId(labelHash);
+                string memory hexString = HexUtils.toHexString(chainIdBytes);
+                return abi.encode(hexString);
+            }
+            
+            // Default: return text value from mapping
+            string memory value = textRecords[labelHash][key];
+            return abi.encode(value);
+        } else if (selector == DATA_SELECTOR) {
+            // data(bytes32,bytes) - decode key and return data value
+            (, bytes memory key) = abi.decode(data[4:], (bytes32, bytes));
+            
+            // Special case for "chain-id" data record
+            if (keccak256(key) == keccak256(CHAIN_ID_DATA_KEY)) {
+                // Return chain ID bytes directly from registry
+                return chainIDRegistry.chainId(labelHash);
+            }
+            
+            // Default: return data value from mapping
+            bytes memory dataValue = dataRecords[labelHash][key];
+            return abi.encode(dataValue);
         }
-
-        chainIdRecords[_node] = _data;
-        if (_data.length != 0) {
-            reverseMapping[keccak256(_data)] = _node;
-        }
-        emit AddressChanged(_node, _key, _data);
     }
+
 
     function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
-        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IENSIPTBD9).interfaceId;
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IExtendedResolver).interfaceId;
     }
 
-    /// @notice Reverse map bytes back to the node.
-    /// @param _data The chain-id bytes that were stored.
-    /// @return node_ The ENS node that owns the payload.
-    function node(bytes calldata _data) external view returns (bytes32) {
-        return reverseMapping[keccak256(_data)];
+
+    /// @notice Set the address for a label hash with a specific coin type.
+    /// @param _labelHash The label hash to update.
+    /// @param _coinType The coin type (default: 60 for Ethereum).
+    /// @param _addr The address to set.
+    function setAddr(bytes32 _labelHash, uint256 _coinType, address _addr) external onlyRole(ADMIN_ROLE) {
+        addressRecords[_labelHash][_coinType] = _addr;
+    }
+
+
+    /// @notice Set the content hash for a label hash.
+    /// @param _labelHash The label hash to update.
+    /// @param _hash The content hash to set.
+    function setContenthash(bytes32 _labelHash, bytes calldata _hash) external onlyRole(ADMIN_ROLE) {
+        contenthashRecords[_labelHash] = _hash;
+    }
+
+    /// @notice Set a text record for a label hash.
+    /// @param _labelHash The label hash to update.
+    /// @param _key The text record key.
+    /// @param _value The text record value.
+    /// @dev Note: "chain-id" text record will be stored but not used - resolve() overrides it with chainIDRegistry value.
+    function setText(bytes32 _labelHash, string calldata _key, string calldata _value) external onlyRole(ADMIN_ROLE) {
+        textRecords[_labelHash][_key] = _value;
+    }
+
+    /// @notice Set a data record for a label hash.
+    /// @param _labelHash The label hash to update.
+    /// @param _key The data record key.
+    /// @param _data The data record value.
+    /// @dev Note: "chain-id" data record will be stored but not used - resolve() overrides it with chainIDRegistry value.
+    function setData(bytes32 _labelHash, bytes calldata _key, bytes calldata _data) external onlyRole(ADMIN_ROLE) {
+        dataRecords[_labelHash][_key] = _data;
+    }
+
+    /// @notice Get the address for a label hash with a specific coin type.
+    /// @param _labelHash The label hash to query.
+    /// @param _coinType The coin type (default: 60 for Ethereum).
+    /// @return The address for this label and coin type.
+    function getAddr(bytes32 _labelHash, uint256 _coinType) external view returns (address) {
+        return addressRecords[_labelHash][_coinType];
+    }
+
+
+    /// @notice Get the content hash for a label hash.
+    /// @param _labelHash The label hash to query.
+    /// @return The content hash for this label.
+    function getContenthash(bytes32 _labelHash) external view returns (bytes memory) {
+        return contenthashRecords[_labelHash];
+    }
+
+    /// @notice Get a text record for a label hash.
+    /// @param _labelHash The label hash to query.
+    /// @param _key The text record key.
+    /// @return The text record value.
+    function getText(bytes32 _labelHash, string calldata _key) external view returns (string memory) {
+        return textRecords[_labelHash][_key];
+    }
+
+    /// @notice Get a data record for a label hash.
+    /// @param _labelHash The label hash to query.
+    /// @param _key The data record key.
+    /// @return The data record value.
+    /// @dev Note: "chain-id" data record will return stored value but resolve() overrides it with chainIDRegistry value.
+    function getData(bytes32 _labelHash, bytes calldata _key) external view returns (bytes memory) {
+        return dataRecords[_labelHash][_key];
+    }
+
+    /// @notice Register a label hash with an owner.
+    /// @param _labelHash The label hash to register.
+    /// @param _owner The owner address for this label hash.
+    function register(bytes32 _labelHash, address _owner) external onlyRole(ADMIN_ROLE) {
+        labelOwners[_labelHash] = _owner;
+    }
+
+    /// @notice Set an operator for the caller (only owner can call).
+    /// @param _operator The operator address to authorize/revoke.
+    /// @param _authorized Whether to authorize or revoke the operator.
+    function setOperator(address _operator, bool _authorized) external {
+        operators[msg.sender][_operator] = _authorized;
+    }
+
+    /// @notice Check if an address is an operator for an owner.
+    /// @param _owner The owner address to check.
+    /// @param _operator The operator address to check.
+    /// @return Whether the address is an authorized operator.
+    function isOperator(address _owner, address _operator) external view returns (bool) {
+        return operators[_owner][_operator];
+    }
+
+    /// @notice Get the owner of a label hash.
+    /// @param _labelHash The label hash to query.
+    /// @return The owner address.
+    function getOwner(bytes32 _labelHash) external view returns (address) {
+        return labelOwners[_labelHash];
+    }
+
+    /// @notice Update the chainID registry address.
+    /// @param _chainIDRegistry The new chainID registry contract address.
+    function updateChainIDRegistry(address _chainIDRegistry) external onlyRole(ADMIN_ROLE) {
+        chainIDRegistry = IChainIDRegistry(_chainIDRegistry);
     }
 }

--- a/src/ReverseChainResolver.sol
+++ b/src/ReverseChainResolver.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title ReverseChainResolver
+/// @author @unruggable-labs
+/// @notice Extended resolver that resolves chain names from chain IDs using ENSIP-10 interface.
+/// @dev This resolver works by:
+///      - Taking DNS-encoded names and extracting the first label hash (but ignoring it)
+///      - For text records with key "chain-name:<chainId_hex>", returns the chain name from chainIDRegistry
+///      - For data records with key "chain-name:<chainId_bytes>", returns the chain name from chainIDRegistry
+///      - All other keys return empty values
+///      - The chainIDRegistry provides the mapping from chain ID to chain name
+///      - Can be deployed on any subdomain (e.g., reverse.cid.eth) since labelhash is ignored
+
+import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
+import {HexUtils} from "@openzeppelin/contracts/utils/HexUtils.sol";
+import {IExtendedResolver} from "./interfaces/IExtendedResolver.sol";
+import {NameCoder} from "./utils/NameCoder.sol";
+
+interface IChainIDRegistry {
+    function chainName(bytes calldata _chainIdBytes) external view returns (string memory _chainName);
+    function chainId(bytes32 labelhash) external view returns (bytes memory _chainId);
+}
+
+contract ReverseChainResolver is IERC165, IExtendedResolver {
+
+    // ENS method selectors
+    bytes4 public constant TEXT_SELECTOR = bytes4(keccak256("text(bytes32,string)"));
+    bytes4 public constant DATA_SELECTOR = bytes4(keccak256("data(bytes32,bytes)"));
+
+    // Text record key prefix
+    string public constant CHAIN_NAME_TEXT_PREFIX = "chain-name:";
+    
+    // Data record key prefix
+    string public constant CHAIN_NAME_DATA_PREFIX = "chain-name:";
+
+    // Base node for cid.eth
+    bytes32 public constant BASE_NODE = keccak256(abi.encodePacked(bytes32(0), keccak256("cid")));
+
+
+    // ChainID Registry contract address
+    IChainIDRegistry public chainIDRegistry;
+
+
+    constructor(address _chainIDRegistry) {
+        chainIDRegistry = IChainIDRegistry(_chainIDRegistry);
+    }
+
+    /// @notice Resolve data for a DNS-encoded name using ENSIP-10 interface.
+    /// @param name The DNS-encoded name.
+    /// @param data The ABI-encoded ENS method call data.
+    /// @return The resolved data based on the method selector.
+    function resolve(bytes calldata name, bytes calldata data) external view override returns (bytes memory) {
+        // Extract the first label from the DNS-encoded name
+        (bytes32 labelHash, , , ) = NameCoder.readLabel(name, 0, true);
+        
+        // Get the method selector (first 4 bytes)
+        bytes4 selector = bytes4(data);
+        
+        if (selector == TEXT_SELECTOR) {
+            // text(bytes32,string) - decode key and return text value
+            (, string memory key) = abi.decode(data[4:], (bytes32, string));
+            
+            // Check if key starts with "chain-name:" prefix
+            bytes memory keyBytes = bytes(key);
+            bytes memory prefixBytes = bytes(CHAIN_NAME_TEXT_PREFIX);
+            if (_startsWith(keyBytes, prefixBytes)) {
+                // Extract chainId from key (remove "chain-name:" prefix)
+                string memory chainIdHex = _substring(key, prefixBytes.length, keyBytes.length);
+                bytes memory chainIdBytes = HexUtils.hexStringToBytes(chainIdHex);
+                string memory chainName = chainIDRegistry.chainName(chainIdBytes);
+                return abi.encode(chainName);
+            }
+            
+            // Return empty bytes for non-chain-name keys
+            return abi.encode("");
+        } else if (selector == DATA_SELECTOR) {
+            // data(bytes32,bytes) - decode key and return data value
+            (, bytes memory key) = abi.decode(data[4:], (bytes32, bytes));
+            
+            // Check if key starts with "chain-name:" prefix
+            bytes memory prefixBytes = abi.encode(CHAIN_NAME_DATA_PREFIX);
+            if (_startsWith(key, prefixBytes)) {
+                // Extract chainId from key (remove "chain-name:" prefix)
+                bytes memory chainIdBytes = new bytes(key.length - prefixBytes.length);
+                for (uint256 i = 0; i < chainIdBytes.length; i++) {
+                    chainIdBytes[i] = key[prefixBytes.length + i];
+                }
+                string memory chainName = chainIDRegistry.chainName(chainIdBytes);
+                return abi.encode(chainName);
+            }
+            
+            // Return empty bytes for non-chain-name keys
+            return abi.encode(bytes(""));
+        }
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IExtendedResolver).interfaceId;
+    }
+
+    /// @notice Check if bytes starts with a prefix
+    /// @param data The bytes to check
+    /// @param prefix The prefix to look for
+    /// @return True if data starts with prefix
+    function _startsWith(bytes memory data, bytes memory prefix) internal pure returns (bool) {
+        if (data.length < prefix.length) return false;
+        for (uint256 i = 0; i < prefix.length; i++) {
+            if (data[i] != prefix[i]) return false;
+        }
+        return true;
+    }
+
+    /// @notice Extract substring from string
+    /// @param str The string to extract from
+    /// @param start The start index
+    /// @param end The end index
+    /// @return The extracted substring
+    function _substring(string memory str, uint256 start, uint256 end) internal pure returns (string memory) {
+        bytes memory strBytes = bytes(str);
+        bytes memory result = new bytes(end - start);
+        for (uint256 i = start; i < end; i++) {
+            result[i - start] = strBytes[i];
+        }
+        return string(result);
+    }
+
+
+}

--- a/src/ReverseChainResolver.sol
+++ b/src/ReverseChainResolver.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.8.25;
 ///      - For data records with key "chain-name:<chainId_bytes>", returns the chain name from chainIDRegistry
 ///      - All other keys return empty values
 ///      - The chainIDRegistry provides the mapping from chain ID to chain name
-///      - Can be deployed on any subdomain (e.g., reverse.cid.eth) since labelhash is ignored
+///      - Can be deployed on any subdomain (e.g., reverse.name.cid.eth) since labelhash is ignored
 
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 import {HexUtils} from "@openzeppelin/contracts/utils/HexUtils.sol";

--- a/src/interfaces/IExtendedResolver.sol
+++ b/src/interfaces/IExtendedResolver.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+interface IExtendedResolver {
+    function resolve(
+        bytes memory name,
+        bytes memory data
+    ) external view returns (bytes memory);
+}

--- a/src/utils/NameCoder.sol
+++ b/src/utils/NameCoder.sol
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {HexUtils} from "../utils/HexUtils.sol";
+
+/// @dev Library for encoding/decoding names.
+///
+/// An ENS name is stop-separated labels, eg. "aaa.bb.c".
+///
+/// A DNS-encoded name is composed of byte length-prefixed labels with a terminator byte.
+/// eg. "\x03aaa\x02bb\x01c\x00".
+/// - maximum label length is 255 bytes.
+/// - length = 0 is reserved for the terminator (root).
+///
+/// To encode a label larger than 255 bytes, use a hashed label.
+/// A label of any length can be converted to a hashed label.
+///
+/// A hashed label is encoded as "[" + toHex(keccak256(label)) + "]".
+/// eg. [af2caa1c2ca1d027f1ac823b529d0a67cd144264b2789fa2ea4d63a67c7103cc] = "vitalik".
+/// - always 66 bytes.
+/// - matches: `/^\[[0-9a-f]{64}\]$/`.
+///
+/// w/o hashed labels: `dns.length == 2 + ens.length` and the mapping is injective.
+///  w/ hashed labels: `dns.length == 2 + ens.split('.').map(x => x.utf8Length).sum(n => n > 255 ? 66 : n)`.
+///
+library NameCoder {
+    /// @dev The DNS-encoded name is malformed.
+    ///      Error selector: `0xba4adc23`
+    error DNSDecodingFailed(bytes dns);
+
+    /// @dev A label of the ENS name has an invalid size.
+    ///      Error selector: `0x9a4c3e3b`
+    error DNSEncodingFailed(string ens);
+
+    /// @dev Read the `size` of the label at `offset`.
+    ///      If `size = 0`, it must be the end of `name` (no junk at end).
+    ///      Reverts `DNSDecodingFailed`.
+    /// @param name The DNS-encoded name.
+    /// @param offset The offset into `name` to start reading.
+    /// @return size The size of the label in bytes.
+    /// @return nextOffset The offset into `name` of the next label.
+    function nextLabel(
+        bytes memory name,
+        uint256 offset
+    ) internal pure returns (uint8 size, uint256 nextOffset) {
+        assembly {
+            size := byte(0, mload(add(add(name, 32), offset))) // uint8(name[offset])
+            nextOffset := add(offset, add(1, size)) // offset + 1 + size
+        }
+        if (size > 0 ? nextOffset >= name.length : nextOffset != name.length) {
+            revert DNSDecodingFailed(name);
+        }
+    }
+
+    /// @dev Find the offset of the label before `offset` in `name`.
+    ///      * `prevOffset(name, 0)` reverts.
+    ///      * `prevOffset(name, name.length + 1)` reverts.
+    ///      * `prevOffset(name, name.length) = name.length - 1`.
+    ///      * `prevOffset(name, name.length - 1) = <tld>`.
+    ///      Reverts `DNSDecodingFailed`.
+    /// @param name The DNS-encoded name.
+    /// @param offset The offset into `name` to start reading backwards.
+    /// @return prevOffset The offset into `name` of the previous label.
+    function prevLabel(
+        bytes memory name,
+        uint256 offset
+    ) internal pure returns (uint256 prevOffset) {
+        while (true) {
+            (, uint256 nextOffset) = nextLabel(name, prevOffset);
+            if (nextOffset == offset) break;
+            if (nextOffset > offset) {
+                revert DNSDecodingFailed(name);
+            }
+            prevOffset = nextOffset;
+        }
+    }
+
+    /// @dev Compute the ENS labelhash of the label at `offset` and the offset for the next label.
+    ///      Disallows hashed label of zero (eg. `[0..0]`) to prevent confusion with terminator.
+    ///      Reverts `DNSDecodingFailed`.
+    /// @param name The DNS-encoded name.
+    /// @param offset The offset into `name` to start reading.
+    /// @param parseHashed If true, supports hashed labels.
+    /// @return labelHash The resulting labelhash.
+    /// @return nextOffset The offset into `name` of the next label.
+    /// @return size The size of the label in bytes.
+    /// @return wasHashed If true, the label was interpreted as a hashed label.
+    function readLabel(
+        bytes memory name,
+        uint256 offset,
+        bool parseHashed
+    )
+        internal
+        pure
+        returns (
+            bytes32 labelHash,
+            uint256 nextOffset,
+            uint8 size,
+            bool wasHashed
+        )
+    {
+        (size, nextOffset) = nextLabel(name, offset);
+        if (
+            parseHashed &&
+            size == 66 &&
+            name[offset + 1] == "[" &&
+            name[nextOffset - 1] == "]"
+        ) {
+            (labelHash, wasHashed) = HexUtils.hexStringToBytes32(
+                name,
+                offset + 2,
+                nextOffset - 1
+            ); // will not revert
+            if (!wasHashed || labelHash == bytes32(0)) {
+                revert DNSDecodingFailed(name); // "readLabel: malformed" or null literal
+            }
+        } else if (size > 0) {
+            assembly {
+                labelHash := keccak256(add(add(name, offset), 33), size)
+            }
+        }
+    }
+
+    /// @dev Same as `BytesUtils.namehash()` but supports hashed labels.
+    function readLabel(
+        bytes memory name,
+        uint256 offset
+    ) internal pure returns (bytes32 labelHash, uint256 nextOffset) {
+        (labelHash, nextOffset, , ) = readLabel(name, offset, true);
+    }
+
+    /// @dev Compute the ENS namehash of `name[:offset]`.
+    ///      Supports hashed labels.
+    ///      Reverts `DNSDecodingFailed`.
+    /// @param name The DNS-encoded name.
+    /// @param offset The offset into name start hashing.
+    /// @return hash The namehash of `name[:offset]`.
+    function namehash(
+        bytes memory name,
+        uint256 offset
+    ) internal pure returns (bytes32 hash) {
+        (hash, offset) = readLabel(name, offset);
+        if (hash != bytes32(0)) {
+            hash = namehash(namehash(name, offset), hash);
+        }
+    }
+
+    /// @dev Compute a child namehash from a parent namehash.
+    /// @param parentNode The namehash of the parent.
+    /// @param labelHash The labelhash of the child.
+    /// @return node The namehash of the child.
+    function namehash(
+        bytes32 parentNode,
+        bytes32 labelHash
+    ) internal pure returns (bytes32 node) {
+        // ~100 gas less than: keccak256(abi.encode(parentNode, labelHash))
+        assembly {
+            mstore(0, parentNode)
+            mstore(32, labelHash)
+            node := keccak256(0, 64)
+        }
+    }
+
+    /// @dev Convert DNS-encoded name to ENS name.
+    ///      Reverts `DNSDecodingFailed`.
+    /// @param dns The DNS-encoded name to convert, eg. `\x03aaa\x02bb\x01c\x00`.
+    /// @return ens The equivalent ENS name, eg. `aaa.bb.c`.
+    function decode(
+        bytes memory dns
+    ) internal pure returns (string memory ens) {
+        unchecked {
+            uint256 n = dns.length;
+            if (n == 1 && dns[0] == 0) return ""; // only valid answer is root
+            if (n < 3) revert DNSDecodingFailed(dns);
+            bytes memory v = new bytes(n - 2); // always 2-shorter
+            uint256 src;
+            uint256 dst;
+            while (src < n) {
+                uint8 len = uint8(dns[src++]);
+                if (len == 0) break;
+                uint256 end = src + len;
+                if (end > dns.length) revert DNSDecodingFailed(dns); // overflow
+                if (dst > 0) v[dst++] = "."; // skip first stop
+                while (src < end) {
+                    bytes1 x = dns[src++]; // read byte
+                    if (x == ".") revert DNSDecodingFailed(dns); // malicious label
+                    v[dst++] = x; // write byte
+                }
+            }
+            if (src != dns.length) revert DNSDecodingFailed(dns); // junk at end
+            return string(v);
+        }
+    }
+
+    /// @dev Convert ENS name to DNS-encoded name.
+    ///      Hashes labels longer than 255 bytes.
+    ///      Reverts `DNSEncodingFailed`.
+    /// @param ens The ENS name to convert, eg. `aaa.bb.c`.
+    /// @return dns The corresponding DNS-encoded name, eg. `\x03aaa\x02bb\x01c\x00`.
+    function encode(
+        string memory ens
+    ) internal pure returns (bytes memory dns) {
+        unchecked {
+            uint256 n = bytes(ens).length;
+            if (n == 0) return hex"00"; // root
+            dns = new bytes(n + 2);
+            uint256 start;
+            assembly {
+                start := add(dns, 32) // first byte of output
+            }
+            uint256 end = start; // remember position to write length
+            for (uint256 i; i < n; i++) {
+                bytes1 x = bytes(ens)[i]; // read byte
+                if (x == ".") {
+                    start = _createHashedLabel(start, end);
+                    if (start == 0) revert DNSEncodingFailed(ens);
+                    end = start; // jump to next position
+                } else {
+                    assembly {
+                        end := add(end, 1) // increase length
+                        mstore(end, x) // write byte
+                    }
+                }
+            }
+            start = _createHashedLabel(start, end);
+            if (start == 0) revert DNSEncodingFailed(ens);
+            assembly {
+                mstore8(start, 0) // terminal byte
+                mstore(dns, sub(start, add(dns, 31))) // truncate length
+            }
+        }
+    }
+
+    /// @dev Write the label length.
+    ///      If longer than 255, writes a hashed label instead.
+    /// @param start The memory offset of the length-prefixed label.
+    /// @param end The memory offset at the end of the label.
+    /// @return next The memory offset for the next label.
+    ///              Returns 0 if label is empty (handled by caller).
+    function _createHashedLabel(
+        uint256 start,
+        uint256 end
+    ) internal pure returns (uint256 next) {
+        uint256 size = end - start; // length of label
+        if (size > 255) {
+            assembly {
+                mstore(0, keccak256(add(start, 1), size)) // compute hash of label
+            }
+            HexUtils.unsafeHex(0, start + 2, 64); // override label with hex(hash)
+            assembly {
+                mstore8(add(start, 1), 0x5B) // "["
+                mstore8(add(start, 66), 0x5D) // "]"
+            }
+            size = 66;
+        }
+        if (size > 0) {
+            assembly {
+                mstore8(start, size) // update length
+            }
+            next = start + 1 + size; // advance
+        }
+    }
+
+    /// @dev Find the offset of `name` that namehashes to `nodeSuffix`.
+    /// @param name The name to search.
+    /// @param nodeSuffix The node to match.
+    /// @return matched True if `name` ends with the suffix.
+    /// @return node The namehash of `name[offset:]`.
+    /// @return prevOffset The offset into `name` of the label before the suffix, or `matchOffset` if no match or prior label.
+    /// @return matchOffset The offset into `name` that namehashes to the `nodeSuffix`, or 0 if no match.
+    function matchSuffix(
+        bytes memory name,
+        uint256 offset,
+        bytes32 nodeSuffix
+    )
+        internal
+        pure
+        returns (
+            bool matched,
+            bytes32 node,
+            uint256 prevOffset,
+            uint256 matchOffset
+        )
+    {
+        (bytes32 labelHash, uint256 next) = readLabel(name, offset);
+        if (labelHash != bytes32(0)) {
+            (matched, node, prevOffset, matchOffset) = matchSuffix(
+                name,
+                next,
+                nodeSuffix
+            );
+            if (node == nodeSuffix) {
+                matched = true;
+                prevOffset = offset;
+                matchOffset = next;
+            }
+            node = namehash(node, labelHash);
+        }
+        if (node == nodeSuffix) {
+            matched = true;
+            prevOffset = matchOffset = offset;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements an ENS chain resolver system with ENSIP-10 support for subname resolution and reverse resolution capabilities.

## Features

### ChainResolver.sol
- Extended resolver implementing ENSIP-10 interface
- Enables subnames like `optimism.cid.eth` to inherit resolver from `cid.eth`
- Resolves chain IDs via chainIDRegistry for "chain-id" text/data records
- Supports address, contenthash, text, and data records per label hash

### ReverseChainResolver.sol
- Reverse resolution for chain names from chain IDs
- Uses "chain-name:" prefixed keys (e.g., `text('chain-name:0xa')`)
- Queries chainIDRegistry for chain name lookups

### Architecture
- **cid.eth**: Base domain with ChainResolver.sol
- **name.cid.eth**: Domain with ReverseChainResolver.sol
- **chainIDRegistry**: Central registry for chain ID ↔ chain name mappings
- **Access control**: ADMIN_ROLE for management functions

## Usage Examples

```solidity
// Forward: optimism.cid.eth text('chain-id') → "0xa"
// Reverse: reverse.name.cid.eth text('chain-name:0xa') → "optimism"
```