### PR TITLE
fix: enforce canonical chain-name keys and update docs to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repo contains a single contract — [`ChainResolver.sol`](src/ChainResolver
 
 ## ChainResolver.sol
 
-- The `chainId` bytes follow the 7930 chain identifier format; see [7930 Chain Identifier](#7930-chain-identifier-no-address).
+- The `chainId` bytes follow the 7930 chain identifier format; see [7930 Chain Identifier](#7930-chain-identifier).
 - Forward mapping: `labelhash → chainId (bytes)`
 - Reverse mapping: `chainId (bytes) → label (string)`
 - Per‑label ENS records: `addr(coinType)`, `contenthash`, `text`, and `data`.
@@ -25,7 +25,7 @@ This repo contains a single contract — [`ChainResolver.sol`](src/ChainResolver
 </p>
 
 Forward resolution (label → 7930):
-The ENS field `text(..., "chain-id")` (per [ENSIP‑5](https://docs.ens.domains/ensip/5)) returns the chain’s 7930 ID as a hex string. The field `data(..., "chain-id")` returns the raw 7930 bytes (per ENSIP‑TBD‑19). This value is written at registration by the contract owner (e.g., a multisig) and the resolver ignores any user‑set text under that key. To resolve a chain ID:
+The ENS field `text(..., "chain-id")` (per [ENSIP‑5](https://docs.ens.domains/ensip/5)) returns the chain’s 7930 ID as a hex string. The field `data(..., "chain-id")` returns the raw 7930 bytes (per [ENSIP‑24: Arbitrary Data Resolution](https://raw.githubusercontent.com/unruggable-labs/ensips/3f181f3be82b140ebc30d4d7caa6242520246dd6/ensips/24.md)). This value is written at registration by the contract owner (e.g., a multisig) and the resolver ignores any user‑set text under that key. To resolve a chain ID:
  - DNS‑encode the ENS name (e.g., `optimism.cid.eth`).
  - Compute the node of the ENS name (e.g., using `ethers`: `namehash(name)`)
  - Calls:
@@ -42,7 +42,7 @@ Reverse resolution (7930 → label):
 
 Pass a key prefixed with `"chain-name:"` and suffixed with the 7930 hex using `text(bytes32 node,string key)` (per ENSIP‑5). In reverse context this returns the chain label for that 7930 ID. This follows the `chain-name:` text key parameter standard (per [ENSIP‑TBD‑17](https://github.com/nxt3d/ensips/blob/ensip-ideas/ensips/ensip-TBD-17.md)). For example:
 
-  - Text key parameter (string): `"chain-name:<7930-hex>"`
+  - Text key parameter (string): `"chain-name:<7930-hex>"` (for example, `"chain-name:00010001010a00"`)
   - Call (using `name = dnsEncode("reverse.cid.eth")`, `node = namehash(name)`):
     - `resolve(name, encode(text(node, serviceKey)))`
 
@@ -75,14 +75,14 @@ ENS fields available via `IExtendedResolver.resolve(name,data)`:
 - `addr(bytes32 node,uint256 coinType)` → bytes (raw multi‑coin value) — per [ENSIP‑9](https://docs.ens.domains/ensip/9)
 - `contenthash(bytes32 node)` → bytes — per [ENSIP‑7](https://docs.ens.domains/ensip/7)
 - `text(bytes32 node,string key)` → string — per ENSIP‑5 (with special handling for `"chain-id"`, `"chain-name"` and `"chain-name:"`)
-- `data(bytes32 node,string key)` → bytes — per ENSIP‑TBD‑19 (with special handling for `"chain-id"`)
+- `data(bytes32 node,string key)` → bytes — per ENSIP‑24 (with special handling for `"chain-id"`)
 
 ## 7930 Chain Identifier
 
 We use the chain identifier variant of ERC‑7930. Examples:
 
-- Optimism (chain 10): `0x000000010001010a00`
-- Arbitrum (chain 102): `0x000000010001016600`
+- Optimism (chain 10): `0x00010001010a00`
+- Arbitrum (chain 102): `0x00010001016600`
 
 See [ERC‑7930: Universal Chain Identifier](https://eips.ethereum.org/EIPS/eip-7930) for the full specification.
 
@@ -161,4 +161,4 @@ bun run deploy/ReverseResolveByChainId.ts -- --chain=sepolia
 - [ENSIP‑11](https://docs.ens.domains/ensip/11) — Coin types (SLIP‑44 mapping)
 - [ENSIP‑TBD‑17](https://github.com/nxt3d/ensips/blob/ensip-ideas/ensips/ensip-TBD-17.md) — Service Key Parameters (e.g., `chain-name:`)
 - [ENSIP‑TBD‑18](https://github.com/nxt3d/ensips/blob/ensip-ideas/ensips/ensip-TBD-18.md) — Global `chain-id` text record
-- [ENSIP‑TBD‑19](https://github.com/nxt3d/ensips/blob/ensip-ideas/ensips/ensip-TBD-19.md) — `data()` records for chain IDs
+- [ENSIP‑24](https://raw.githubusercontent.com/unruggable-labs/ensips/3f181f3be82b140ebc30d4d7caa6242520246dd6/ensips/24.md) — Arbitrary Data Resolution (`data()` records)

--- a/deploy/SetRecords.ts
+++ b/deploy/SetRecords.ts
@@ -128,7 +128,8 @@ try {
   // Set addr(60)
   if (await promptContinueOrExit(rl, 'Set addr(60)? (y/n): ')) {
     const a60 = (await askQuestion(rl, 'ETH address: ')).trim();
-    const tx = await resolver.setAddr(labelhash, a60);
+    const setAddr60 = resolver.getFunction('setAddr(bytes32,address)');
+    const tx = await setAddr60(labelhash, a60);
     await tx.wait();
     console.log('✓ setAddr(60)');
   }
@@ -139,7 +140,8 @@ try {
     const coinType = BigInt(coinTypeStr);
     const addr = (await askQuestion(rl, 'address (bytes: 0x.. or utf8): ')).trim();
     const val = toBytesLike(addr);
-    const tx = await resolver.setAddr(labelhash, coinType, val);
+    const setAddrCoin = resolver.getFunction('setAddr(bytes32,uint256,bytes)');
+    const tx = await setAddrCoin(labelhash, coinType, val);
     await tx.wait();
     console.log(`✓ setAddr(${coinType})`);
   }

--- a/src/ChainResolver.sol
+++ b/src/ChainResolver.sol
@@ -235,7 +235,7 @@ contract ChainResolver is Ownable, IERC165, IExtendedResolver, IChainResolver {
         onlyAuthorized(_labelhash)
     {
         dataRecords[_labelhash][_key] = _data;
-        emit DataChanged(_labelhash, _key, _key, _data);
+        emit DataChanged(_labelhash, keccak256(bytes(_key)), keccak256(_data));
     }
 
     /**

--- a/src/interfaces/IChainResolver.sol
+++ b/src/interfaces/IChainResolver.sol
@@ -21,7 +21,7 @@ interface IChainResolver {
     event OperatorSet(address indexed _owner, address indexed _operator, bool _isOperator);
     event AddrChanged(bytes32 indexed _labelhash, address _owner);
     event AddressChanged(bytes32 indexed node, uint256 coinType, bytes newAddress);
-    event DataChanged(bytes32 node, string indexed indexedKey, string key, bytes data);
+    event DataChanged(bytes32 node, bytes32 indexed keyHash, bytes32 indexed dataHash);
 
     /// @notice Errors
     error InvalidDataLength();

--- a/test/ChainResolver.blocksmith.ts
+++ b/test/ChainResolver.blocksmith.ts
@@ -47,7 +47,7 @@ async function main() {
     // Test data
     const label = 'optimism';
     const LABEL_HASH = keccak256(toUtf8Bytes(label));
-    const CHAIN_ID_HEX = '0x000000010001010a00';
+    const CHAIN_ID_HEX = '0x00010001010a00';
     const CHAIN_ID = getBytes(CHAIN_ID_HEX);
     section('Inputs');
     log('label', label);

--- a/test/ChainResolverAuth.t.sol
+++ b/test/ChainResolverAuth.t.sol
@@ -16,7 +16,7 @@ contract ChainResolverAuthTest is Test {
     // Test data - using 7930 chain ID format
     string public constant LABEL = "optimism";
     string public constant CHAIN_NAME = "optimism";
-    bytes public constant CHAIN_ID = hex"000000010001010a00";
+    bytes public constant CHAIN_ID = hex"00010001010a00";
     bytes32 public constant LABEL_HASH = keccak256(bytes(LABEL));
 
     function setUp() public {

--- a/test/ChainResolverDataFormats.t.sol
+++ b/test/ChainResolverDataFormats.t.sol
@@ -17,7 +17,7 @@ contract ChainResolverDataFormatsTest is Test {
 
     // Test data - using 7930 chain ID format
     string public constant CHAIN_NAME = "optimism";
-    bytes public constant CHAIN_ID = hex"000000010001010a00";
+    bytes public constant CHAIN_ID = hex"00010001010a00";
     bytes32 public constant LABEL_HASH = keccak256(bytes(CHAIN_NAME));
 
     function setUp() public {
@@ -272,10 +272,10 @@ contract ChainResolverDataFormatsTest is Test {
 
         bytes[] memory testChainIds = new bytes[](5);
         testChainIds[0] = hex""; // Empty chain ID
-        testChainIds[1] = hex"000000010001010a00"; // Normal chain ID
-        testChainIds[2] = hex"000000010001016600"; // Another normal chain ID
+        testChainIds[1] = hex"00010001010a00"; // Normal chain ID
+        testChainIds[2] = hex"00010001016600"; // Another normal chain ID
         testChainIds[3] = new bytes(1000); // Very long chain ID
-        testChainIds[4] = hex"000000010001010a00"; // Duplicate chain ID
+        testChainIds[4] = hex"00010001010a00"; // Duplicate chain ID
 
         // Fill very long chain ID
         for (uint256 i = 0; i < testChainIds[3].length; i++) {

--- a/test/ChainResolverENSForward.t.sol
+++ b/test/ChainResolverENSForward.t.sol
@@ -17,7 +17,7 @@ contract ChainResolverENSForwardTest is Test {
     string public constant CHAIN_NAME = "optimism";
     // 7930 format: Version(4) + ChainType(2) + ChainRefLen(1) + ChainRef(1) + AddrLen(1) + Addr(0)
     // Version: 0x00000001, ChainType: 0x0001 (Ethereum), ChainRefLen: 0x01, ChainRef: 0x0a (10), AddrLen: 0x00, Addr: (empty)
-    bytes public constant CHAIN_ID = hex"000000010001010a00";
+    bytes public constant CHAIN_ID = hex"00010001010a00";
     bytes32 public constant LABEL_HASH = keccak256(bytes(CHAIN_NAME));
 
     function setUp() public {
@@ -89,9 +89,8 @@ contract ChainResolverENSForwardTest is Test {
         vm.startPrank(user1);
 
         bytes memory testData = hex"deadbeef";
-        // Expect DataChanged event (node, indexedKey, key, data)
-        vm.expectEmit(true, true, true, true);
-        emit IChainResolver.DataChanged(LABEL_HASH, "custom", "custom", testData);
+        vm.expectEmit(true, true, false, true);
+        emit IChainResolver.DataChanged(LABEL_HASH, keccak256(bytes("custom")), keccak256(testData));
         resolver.setData(LABEL_HASH, "custom", testData);
 
         // Verify data record
@@ -146,7 +145,7 @@ contract ChainResolverENSForwardTest is Test {
         string memory resolvedChainId = abi.decode(result, (string));
 
         // Should return hex representation of chain ID (without 0x prefix)
-        string memory expectedHex = "000000010001010a00";
+        string memory expectedHex = "00010001010a00";
         assertEq(resolvedChainId, expectedHex, "Override should return canonical chain-id, ignoring stored text");
 
         console.log("Successfully resolved chain-id text record");

--- a/test/ChainResolverENSReverse.t.sol
+++ b/test/ChainResolverENSReverse.t.sol
@@ -20,15 +20,15 @@ contract ChainResolverENSReverseTest is Test {
     string public constant CHAIN_NAME = "Optimism"; // human-readable name distinct from label
     // 7930 format: Version(4) + ChainType(2) + ChainRefLen(1) + ChainRef(1) + AddrLen(1) + Addr(0)
     // Version: 0x00000001, ChainType: 0x0001 (Ethereum), ChainRefLen: 0x01, ChainRef: 0x0a (10), AddrLen: 0x00, Addr: (empty)
-    bytes public constant CHAIN_ID = hex"000000010001010a00";
+    bytes public constant CHAIN_ID = hex"00010001010a00";
     bytes32 public constant LABEL_HASH = keccak256(bytes(LABEL));
 
     // Precomputed DNS-encoded names
     // cid.eth => 0x03 'cid' 0x03 'eth' 0x00
     bytes internal constant DNS_CID_ETH = hex"036369640365746800";
 
-    // Encoded key for reverse text query: "chain-name:" + <7930 hex w/out 0x>
-    string internal constant KEY_CHAIN_NAME = "chain-name:000000010001010a00";
+    // Encoded key for reverse text query: "chain-name:" + <7930 hex (no 0x prefix)>
+    string internal constant KEY_CHAIN_NAME = "chain-name:00010001010a00";
 
     function setUp() public {
         vm.startPrank(admin);
@@ -100,7 +100,7 @@ contract ChainResolverENSReverseTest is Test {
         vm.stopPrank();
 
         // Test reverse resolution for unknown chain ID
-        bytes memory unknownChainId = hex"000000010001019900"; // 7930 format for chain 153 (unknown)
+        bytes memory unknownChainId = hex"00010001019900"; // 7930 format for chain 153 (unknown)
         string memory resolvedName = resolver.chainName(unknownChainId);
 
         assertEq(resolvedName, "", "Should return empty string for unknown chain ID");

--- a/test/ChainResolverEdgeCases.t.sol
+++ b/test/ChainResolverEdgeCases.t.sol
@@ -16,7 +16,7 @@ contract ChainResolverEdgeCasesTest is Test {
 
     // Test data - using 7930 chain ID format
     string public constant CHAIN_NAME = "optimism";
-    bytes public constant CHAIN_ID = hex"000000010001010a00";
+    bytes public constant CHAIN_ID = hex"00010001010a00";
     bytes32 public constant LABEL_HASH = keccak256(bytes(CHAIN_NAME));
 
     function setUp() public {

--- a/test/ChainResolverEnumeration.t.sol
+++ b/test/ChainResolverEnumeration.t.sol
@@ -14,8 +14,8 @@ contract ChainResolverEnumerationTest is Test {
     address public user2 = address(0x3);
 
     // Example 7930 chain IDs
-    bytes public constant OP_ID = hex"000000010001010a00"; // Optimism
-    bytes public constant ARB_ID = hex"000000010001016600"; // Arbitrum
+    bytes public constant OP_ID = hex"00010001010a00"; // Optimism
+    bytes public constant ARB_ID = hex"00010001016600"; // Arbitrum
 
     function setUp() public {
         vm.startPrank(admin);

--- a/test/ChainResolverRegistry.t.sol
+++ b/test/ChainResolverRegistry.t.sol
@@ -17,13 +17,13 @@ contract ChainResolverRegistryTest is Test {
     string public constant CHAIN_NAME = "optimism";
     // 7930 format: Version(4) + ChainType(2) + ChainRefLen(1) + ChainRef(1) + AddrLen(1) + Addr(0)
     // Version: 0x00000001, ChainType: 0x0001 (Ethereum), ChainRefLen: 0x01, ChainRef: 0x0a (10), AddrLen: 0x00, Addr: (empty)
-    bytes public constant CHAIN_ID = hex"000000010001010a00";
+    bytes public constant CHAIN_ID = hex"00010001010a00";
     bytes32 public constant LABEL_HASH = keccak256(bytes(CHAIN_NAME));
 
     string public constant CHAIN_NAME_2 = "arbitrum";
     // 7930 format: Version(4) + ChainType(2) + ChainRefLen(1) + ChainRef(1) + AddrLen(1) + Addr(0)
     // Version: 0x00000001, ChainType: 0x0001 (Ethereum), ChainRefLen: 0x01, ChainRef: 0x66 (102), AddrLen: 0x00, Addr: (empty)
-    bytes public constant CHAIN_ID_2 = hex"000000010001016600";
+    bytes public constant CHAIN_ID_2 = hex"00010001016600";
     bytes32 public constant LABEL_HASH_2 = keccak256(bytes(CHAIN_NAME_2));
 
     function setUp() public {


### PR DESCRIPTION
- Enforce canonical ERC-7930 Chain ids
- Update `DataChanged()` event
- Update ENSIP-TBD-19 to ensip-24
- Update docs to reflect reverse resolution functionality